### PR TITLE
Adds a target group ID and FROM email address API

### DIFF
--- a/CRM/Birthdays/Mailer.php
+++ b/CRM/Birthdays/Mailer.php
@@ -25,9 +25,10 @@ class CRM_Birthdays_Mailer
     private ?string $email_address_from;
 
     /**
+     * @param string $custom_sender_email Optional custom sender email to override settings
      * @throws Exception
      */
-    public function __construct()
+    public function __construct(string $custom_sender_email = '')
     {
         $this->template_id = Civi::settings()->get(CRM_Birthdays_Form_Settings::BIRTHDAYS_MESSAGE_TEMPLATE);
         if (empty($this->template_id)) {
@@ -37,13 +38,19 @@ class CRM_Birthdays_Mailer
         }
 
         try {
-            $email_name_mix = Civi::settings()->get(CRM_Birthdays_Form_Settings::BIRTHDAYS_SENDER_EMAIL_ADDRESS);
-            /*
-             * Examples:
-             * - Input: "to database" <database@domain.com>
-             * - Output: database@domain.com
-             */
-            $this->email_address_from = CRM_Utils_Mail::pluckEmailFromHeader($email_name_mix);
+            if (!empty($custom_sender_email)) {
+                // Use custom sender email if provided
+                $this->email_address_from = $custom_sender_email;
+            } else {
+                // Use sender email from settings
+                $email_name_mix = Civi::settings()->get(CRM_Birthdays_Form_Settings::BIRTHDAYS_SENDER_EMAIL_ADDRESS);
+                /*
+                 * Examples:
+                 * - Input: "to database" <database@domain.com>
+                 * - Output: database@domain.com
+                 */
+                $this->email_address_from = CRM_Utils_Mail::pluckEmailFromHeader($email_name_mix);
+            }
         } catch (TypeError $typeError) {
             throw new Exception(
                 E::LONG_NAME . " " . "Pre selected outgoing email not found. Please set an outgoing email address in birthday settings $typeError"

--- a/Civi/Api4/Birthdays.php
+++ b/Civi/Api4/Birthdays.php
@@ -22,6 +22,7 @@ namespace Civi\Api4;
 use Civi\Api4\Generic\AbstractEntity;
 use Civi\Api4\Generic\BasicGetFieldsAction;
 use Civi\Api4\Action\Birthdays\sendGreetings;
+
 /**
  * Birthdays API
  *

--- a/api/v3/Birthdays.php
+++ b/api/v3/Birthdays.php
@@ -41,6 +41,20 @@ function _civicrm_api3_birthdays_sendgreetings_spec(&$params) {
         'title'        => E::ts('Option to disable activities (default: no)'),
         'description'  => E::ts('Should activities be disabled?')
     ];
+    $params['custom_sender_email'] = [
+        'name'         => 'custom_sender_email',
+        'api.required' => 0,
+        'type'         => CRM_Utils_Type::T_STRING,
+        'title'        => E::ts('Custom sender email address'),
+        'description'  => E::ts('Override the default sender email address from settings')
+    ];
+    $params['target_group_id'] = [
+        'name'         => 'target_group_id',
+        'api.required' => 0,
+        'type'         => CRM_Utils_Type::T_INT,
+        'title'        => E::ts('Target group ID'),
+        'description'  => E::ts('Override the default birthday group with a custom group ID')
+    ];
 }
 
 /**
@@ -58,10 +72,14 @@ function civicrm_api3_birthdays_sendgreetings(array $params): array
     try {
         $debug_email = $params['debug_email'] ?? '';
         $disable_activities = (bool) ($params['disable_activities'] ?? NULL);
+        $custom_sender_email = $params['custom_sender_email'] ?? '';
+        $target_group_id = (int) ($params['target_group_id'] ?? 0);
 
         $api_status_info = \Civi\Api4\Birthdays::sendGreetings()
             ->setDisable_activities($disable_activities)
             ->setDebug_email($debug_email)
+            ->setCustom_sender_email($custom_sender_email)
+            ->setTarget_group_id($target_group_id)
             ->execute()
             ->first();
 


### PR DESCRIPTION
This functionality adds couple of API parameters to send the notification to a specific group.
It can also override the default FROM address of CiviCRM

 **How to use:**
 
API Entity: Birthdays
API Action: sendgreetings
API Parameters:
target_group_id=5
custom_sender_email=volunteers@example.com